### PR TITLE
Update attachment start API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ chrono = { version = "0.4.22", default-features = false, features = ["std", "ser
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from", "from_str", "into"] }
 futures = { version = "0.3.21", default-features = false, features = ["alloc"] }
 hmac = "0.12.1"
-imagesize = "0.11.0"
+imagesize = { version = "0.11.0", optional = true }
 pbkdf2 = { version = "0.11.0", default-features = false }
 reqwest = { version = "0.11.11", default-features = false, features = ["cookies", "json", "multipart", "stream"] }
 serde = { version = "1.0.138", features = ["derive"] }
@@ -35,3 +35,4 @@ tracing-subscriber = { version = "0.3.14", features = ["env-filter"] }
 default = ["default-tls", "fs"]
 default-tls = ["reqwest/default-tls"]
 fs = ["tokio/fs", "tokio-util/codec"]
+imagesize = ["dep:imagesize", "fs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4.22", default-features = false, features = ["std", "ser
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from", "from_str", "into"] }
 futures = { version = "0.3.21", default-features = false, features = ["alloc"] }
 hmac = "0.12.1"
+imagesize = "0.11.0"
 pbkdf2 = { version = "0.11.0", default-features = false }
 reqwest = { version = "0.11.11", default-features = false, features = ["cookies", "json", "multipart", "stream"] }
 serde = { version = "1.0.138", features = ["derive"] }


### PR DESCRIPTION
- API is now more strict about requiring an integer for `contentLength`. Numeric strings are no longer accepted.
- `width` and `height` are now available (albeit optional) fields. Including these is preferred. I included an implementation for this, although I am amateurish at rust so my way of getting around borrowing `path` after moving (clones!) is probably incorrect. Would love to know what's actually idiomatic here.

Tested this works as expected with no changes required for `examples/post.rs`.